### PR TITLE
Make decode more robust

### DIFF
--- a/src/hashids/impl.clj
+++ b/src/hashids/impl.clj
@@ -177,19 +177,21 @@
 (defn decode
   [opts encstr]
   {:pre [(string? encstr)]}
-  (let [{:keys [seps alphabet salt min-length guards]} (setup opts)
-        breakdown (split-on-chars encstr guards)
-        breakdown-idx (if (some #{(count breakdown)} '(2 3)) 1 0)
-        bdn (nth breakdown breakdown-idx)
-        lottery (first bdn)
-        arr (split-on-chars (drop 1 bdn) seps)
-        decoded-result (seq (second (reduce (fn [[prev-alph ret] sub-hash]
-                        (let [buf (str lottery salt prev-alph)
-                              alph (consistent-shuffle prev-alph (subs buf 0 (count prev-alph)))]
-                          [alph (conj ret (dehash sub-hash alph))]))
-                      [alphabet []]
-                      arr)))]
-    (if (= encstr
-           (encode opts decoded-result))
-      decoded-result
-      '())))
+  (if (< (count encstr) 2)
+    '()
+    (let [{:keys [seps alphabet salt min-length guards]} (setup opts)
+          breakdown (split-on-chars encstr guards)
+          breakdown-idx (if (some #{(count breakdown)} '(2 3)) 1 0)
+          bdn (nth breakdown breakdown-idx)
+          lottery (first bdn)
+          arr (split-on-chars (drop 1 bdn) seps)
+          decoded-result (seq (second (reduce (fn [[prev-alph ret] sub-hash]
+                          (let [buf (str lottery salt prev-alph)
+                                alph (consistent-shuffle prev-alph (subs buf 0 (count prev-alph)))]
+                            [alph (conj ret (dehash sub-hash alph))]))
+                        [alphabet []]
+                        arr)))]
+      (if (and (some? decoded-result) (= encstr
+             (encode opts decoded-result)))
+        decoded-result
+        '()))))

--- a/test/hashids/impl_test.clj
+++ b/test/hashids/impl_test.clj
@@ -93,6 +93,15 @@
   (is (= '() (decode {:salt "xyzzy"} (encode {:salt "abcde"} [0 1 2]))))
   (is (= '() (decode {:salt "xyzzy"} (encode {:salt "z"} [9000])))))
 
+(deftest decode-returns-empty-collection-for-illegal-hashes
+  "ensure that decoding an unknown hash returns an empty collection"
+  (is (= '() (decode {:salt "xyzzy"} "a")))
+  (is (= '() (decode {:salt "xyzzy"} "b")))
+  (is (= '() (decode {:salt "xyzzy"} "f")))
+  (is (= '() (decode {:salt "xyzzy"} "m")))
+  (is (= '() (decode {:salt "xyzzy"} "af")))
+  (is (= '() (decode {:salt "xyzzy"} "bh"))))
+
 (deftest ensure-min-length-sanity-check
   (is (= "B0NkK9A5" ((ensure-min-length {:min-length 8
                                          :alphabet "4VNWO5kPrnZ1Y3LgKoBmXyzwb9aMj7l2RDQ6EJexqv8p"


### PR DESCRIPTION
* always return '() for undecodeable input
* allow single characters as input
* check if decoded is nil

Reasoning: decode crashed for strings of length 1 because the decoded-result was nil.
For input "m", decode failed with an IndexOutOfBoundsException because breakdown-idx in impl.clj became 0.

I added some checks in decode to make it more robust. Please see if there is a better way to accomplish this.